### PR TITLE
Display logfile

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ description:         Please see the README on GitHub at <https://github.com/Will
 dependencies:
 - base >= 4.7 && < 5
 - time >= 1.8.0.2
+- containers >= 0.6.0.1
 
 library:
   source-dirs: src

--- a/src/Display.hs
+++ b/src/Display.hs
@@ -1,6 +1,7 @@
 module Display
   ( displaySession  
   , prettifySession
+  , displayLogFile
   ) where
 
 import SessionTypes
@@ -40,3 +41,16 @@ prettifySession ses = concat $ intersperse "\n" [a, b, c, d]
         ms = maximum [maximum . map length $ ws, maximum. map length $ rs]
         c = lineBuilder ws ms "|"
         d = lineBuilder rs ms "|"
+
+printStrings :: [String] -> IO ()
+printStrings [] = return ()
+printStrings (x:xs) = do
+  putStrLn x
+  printStrings xs
+
+displayLogFile :: FilePath -> IO ()
+displayLogFile path = do
+  sessions <- readLogFile path
+  let sessionstrings = map prettifySession sessions
+  printStrings sessionstrings
+

--- a/src/Display.hs
+++ b/src/Display.hs
@@ -6,9 +6,11 @@ module Display
 
 import SessionTypes
 import LoadSessions
+import LogAggregators
 import System.IO
-import Data.List
+import Data.List as List
 import Data.Time
+import Data.Map.Strict as Map
 
 
 displaySession :: Session -> IO ()
@@ -22,11 +24,11 @@ numberOfSets ses = length $ sets ses
 cellBuilder :: String -> Int -> String -> String
 cellBuilder separator max_size mssg =
   separator ++ padding ++ mssg ++ " "
-  where padding = concat (take (1 + max_size - length mssg) $ repeat " ")
+  where padding = concat (List.take (1 + max_size - length mssg) $ repeat " ")
 
 lineBuilder :: [String] -> Int -> String -> String
 lineBuilder mssgs max_size separator =
-  concat $ map (cellBuilder "|" max_size) $ mssgs
+  concat $ List.map (cellBuilder "|" max_size) $ mssgs
 
 showWeight :: Weight -> String
 showWeight BodyWeight = "bw"
@@ -34,13 +36,27 @@ showWeight (TrainingWeight a) = show a
 
 prettifySession :: Session -> String
 prettifySession ses = concat $ intersperse "\n" [a, b, c, d]
-  where a = kind ses
+  where a = "\n" ++ kind ses
         b = concat $ replicate (length a) "-"
-        ws = map showWeight $ extractFromSets weight ses
-        rs = map show $ extractFromSets reps ses
-        ms = maximum [maximum . map length $ ws, maximum. map length $ rs]
+        ws = List.map showWeight $ extractFromSets weight ses
+        rs = List.map show $ extractFromSets reps ses
+        ms = maximum [maximum . List.map length $ ws, maximum . List.map length $ rs]
         c = lineBuilder ws ms "|"
         d = lineBuilder rs ms "|"
+
+prettifySessionGroup' :: String -> [Session] -> [String]
+prettifySessionGroup' date lses =
+  [datehdr] ++ (List.map prettifySession lses)
+  where datehdr = ">>>>>>>>" ++ date ++ "<<<<<<<<\n"
+
+accum :: [String] -> String -> [Session] -> ([String], Maybe c)
+accum a key lses =
+  (a ++ [datehdr] ++ (List.map prettifySession lses), Nothing)
+  where datehdr = "\n>>>>>>>>" ++ key ++ "<<<<<<<<\n"
+
+prettifySessionGroup :: Map.Map String [Session] -> [String]
+prettifySessionGroup mses =
+  fst $ Map.mapAccumWithKey accum [] mses
 
 printStrings :: [String] -> IO ()
 printStrings [] = return ()
@@ -51,6 +67,12 @@ printStrings (x:xs) = do
 displayLogFile :: FilePath -> IO ()
 displayLogFile path = do
   sessions <- readLogFile path
-  let sessionstrings = map prettifySession sessions
+  let sessionstrings = List.map prettifySession sessions
   printStrings sessionstrings
 
+-- WIP
+displayLogFile2 :: FilePath -> IO ()
+displayLogFile2 path = do
+  groupedSessions <- fmap groupSessionsByDate $ readLogFile path
+  let sessionStrings = prettifySessionGroup groupedSessions
+  printStrings sessionStrings

--- a/src/LoadSessions.hs
+++ b/src/LoadSessions.hs
@@ -1,7 +1,7 @@
-module LoadSessions (
-  readLogFile,
-  readSession,
-  extractFromSets
+module LoadSessions
+  ( readLogFile
+  , readSession
+  , extractFromSets
   ) where
 
 import System.IO

--- a/src/LogAggregators.hs
+++ b/src/LogAggregators.hs
@@ -1,0 +1,40 @@
+module LogAggregators
+  ( groupSessionsByDate
+  ) where
+
+import SessionTypes
+import Data.Time
+import Data.Map.Strict as Map
+
+
+-- use a Strict Map (a Dict) as a grouping for sessions!
+-- the groupSessionsByDate will just fill that Dict
+-- by folding
+
+-- Our fixed time string
+zonedTimeToString :: ZonedTime -> String
+zonedTimeToString zt = formatTime defaultTimeLocale "%Y-%m-%d" zt
+
+-- surely there's an out-of-the-box function for this?
+sessionInserter :: Session -> Map.Map String [Session] -> Map.Map String [Session]
+sessionInserter s m = 
+  let sdate = zonedTimeToString $ time s
+      slist = Map.lookup sdate m
+  in
+    case slist of
+      Nothing -> Map.insert sdate [s] m
+      Just _ -> Map.update (\l -> Just (l ++ [s])) sdate m
+
+groupSessionsByDate :: [Session] -> Map.Map String [Session]
+groupSessionsByDate lses = Prelude.foldr sessionInserter Map.empty lses
+
+
+
+
+
+
+
+
+
+
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,8 @@ packages:
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
-# extra-deps: []
+extra-deps:
+- containers-0.6.0.1
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
fixes #3 

This PR adds a pretty-print method for printing the log file; grouped by dates and printed with a date header.

E.g.:

```
>>>>>>>>2020-01-26<<<<<<<<


crunches
---------
| bw | bw | bw 
| 30 | 20 | 25 

dumbbell flyes
---------------
| 17.5 | 17.5 | 15.0 | 12.5 
|    7 |    5 |    7 |    9 

>>>>>>>>2020-01-30<<<<<<<<


dumbbell curl
--------------
| 15.0 | 12.5 | 10.0 |  7.5 
|    8 |    8 |    9 |   12 


```

Currently, the only way to actually use this function is to load `Display.hs` in `ghci` and call `displayLogFile2` on the path to the log file. There is room for some future improvement here. :smile:  