### PR TITLE
Add testing 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,9 +9,9 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-- script: stack upgrade
-  displayName: 'Prepare stack'
 
-- script: stack build
-  displayName: 'Build the loft package'
+  - bash: stack build
+    displayName: 'Build the loft package'
 
+  - script: stack test
+    displayName: 'Run the tests'

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,8 @@ dependencies:
 - base >= 4.7 && < 5
 - time >= 1.8.0.2
 - containers >= 0.6.0.1
+- QuickCheck >= 2.13.2
+- hspec >= 2.0
 
 library:
   source-dirs: src

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,8 +39,11 @@ packages:
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
+
 extra-deps:
 - containers-0.6.0.1
+- QuickCheck-2.13.2
+- hspec-2.7.1
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/test/SessionTypesSpec.hs
+++ b/test/SessionTypesSpec.hs
@@ -1,0 +1,42 @@
+module SessionTypesSpec (spec) where
+
+import Test.QuickCheck
+import Test.Hspec
+import SessionTypes
+import Data.Time
+
+-- TODO: extend the ZonedTime Arbitrary instance to have random time too
+instance Arbitrary ZonedTime where
+  arbitrary = do
+    y <- choose (1, 9999)
+    m <- choose (1, 12)
+    d <- choose (1, gregorianMonthLength y m)
+    return $ ZonedTime (LocalTime (fromGregorian y m d) midnight) utc
+
+instance Arbitrary Weight where
+  arbitrary = oneof
+    [ return BodyWeight
+    , TrainingWeight <$> arbitrary
+    ]
+
+instance Arbitrary TrainingSet where
+  arbitrary = TrainingSet <$> arbitrary <*> arbitrary
+
+instance Arbitrary Session where
+  arbitrary = Session <$> arbitrary <*> arbitrary <*> arbitrary
+
+-- To generate an arbitrary Bob; generate (arbitrary :: Gen Bob)
+
+-- There should be a xxSpec.hs file for each src module. We'll need these instances of Arbitrary
+-- in all the other tests. Does it suffice to import this module?
+
+-- Now we need a test. SessionTypes only contains a single function, so let's test that
+
+prop :: (Session, TrainingSet) -> Bool
+prop (ses, ts) = (length $ sets (addSet ses ts)) == (length $ sets ses) + 1
+
+
+spec :: Spec
+spec = do
+  describe "SessionTypes" $ do
+    it "Adds a set" $ property $ prop

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,1 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
Add tests to loft using hspec and quickcheck. This PR sets up the basic skeleton for that and provides a single quickcheck-powered test (of the `addSet` function).